### PR TITLE
Observable now utilize FB_List for storing observers

### DIFF
--- a/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/Actions/FB_NotifyObserverAction.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/Actions/FB_NotifyObserverAction.TcPOU
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_NotifyObserverAction" Id="{8cb99936-b569-4eab-bcc8-0631bace8fa9}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_NotifyObserverAction EXTENDS FB_Action
+VAR
+    _pData: POINTER TO BYTE;
+    _nSize: UDINT;
+    _nTypeClass: __SYSTEM.TYPE_CLASS;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+    <Method Name="Execute" Id="{87f751f9-c536-4b1f-996b-5ae96ee166a6}">
+      <Declaration><![CDATA[METHOD  Execute
+VAR_INPUT
+    ipObject: I_Object;
+END_VAR
+VAR
+    ipObs: I_Observer;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[__QUERYINTERFACE(ipObject, ipObs);
+
+IF ipObs = 0 THEN
+    RETURN;
+END_IF
+
+ipObs.UpdateP(pData := THIS^._pData,
+              nTypeClass := THIS^._nTypeClass,
+              nSize := THIS^._nSize);
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="Inputs" Id="{f57e0d64-abd4-42b5-8230-4dbde712a3ff}">
+      <Declaration><![CDATA[METHOD Inputs : I_Action
+VAR_INPUT
+    pData:          POINTER TO BYTE;
+    nTypeClass:     __SYSTEM.TYPE_CLASS;
+    nSize:          UDINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Inputs := THIS^;
+
+THIS^._pData := pData;
+THIS^._nTypeClass := nTypeClass;
+THIS^._nSize := nSize;
+]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/FB_AbstractObservable.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/FB_AbstractObservable.TcPOU
@@ -5,14 +5,13 @@
 VAR
     // Attributes
     _nTypeClass:                __SYSTEM.TYPE_CLASS;
-    _bAutoNotify:               BOOL; // Notify automatically on write access of observable value
-    _bNotifyWhenChanged:        BOOL := TRUE; // Notify only when the value is actually changed
+    _bAutoNotify:               BOOL := TRUE; // Notify automatically on write access of observable value
+    _bNotifyWhenChanged:        BOOL; // Notify only when the value is actually changed
 
     // Dynamic mem
-    fbMemMan:                   FB_DynMem_Manager;
-    fbBuffer:                   FB_DynMem_Buffer(ipMemMan := fbMemMan);
-    pipObserver:                POINTER TO I_Observer;
-    aPip:                       ARRAY [0..Param_Observer.cMaxNumberOfObservers-1] OF POINTER TO I_Observer; // Debug array
+    _fbObsList:                 FB_List; // Observer list
+
+    _fbNotifyObservers:         FB_NotifyObserverAction;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -22,64 +21,20 @@ END_VAR
       <Declaration><![CDATA[METHOD Attach : BOOL
 VAR_INPUT
     ipObserver:     I_Observer;
-END_VAR
-VAR
-    i:              UDINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[// Validate interface pointer
-IF ipObserver = 0 THEN
+        <ST><![CDATA[IF ipObserver = 0 // Invalid interface pointer
+    OR_ELSE ipObserver.nTypeClass <> THIS^._nTypeClass // Invalid type
+    OR_ELSE THIS^.Contains(ipObserver) // Already added
+    THEN
     RETURN;
 END_IF
 
-// Max number of observers reached
-IF THIS^.nObserverCount >= Param_Observer.cMaxNumberOfObservers THEN
-    RETURN;
-END_IF
+Attach := THIS^._fbObsList.AddItem(ipObserver) <> -1;
 
-// Incompatible type
-IF ipObserver.nTypeClass <> THIS^.nTypeClass THEN
-    RETURN;
-END_IF
-
-// Create buffer and add observer
-IF NOT THIS^.fbBuffer.bAvailable THEN
-    THIS^.fbBuffer.CreateBuffer(nSize := SIZEOF(THIS^.pipObserver),
-                                bReset := TRUE);
-
-    THIS^.pipObserver := THIS^.fbBuffer.pBuffer;
-    THIS^.pipObserver[THIS^.nLastIdx] := ipObserver;
+IF Attach THEN
     THIS^.NotifyLast();
-
-    {IF defined(variable: aPip)}
-    THIS^.UpdateDebugArray();
-    {END_IF}
-
-    Attach := TRUE;
-    RETURN;
 END_IF
-
-// Make sure observer is not already in the buffer
-FOR i := 0 TO THIS^.nLastIdx DO
-    IF THIS^.pipObserver[i] = ipObserver THEN
-        RETURN;
-    END_IF
-END_FOR
-
-// Increase buffer size and add observer
-THIS^.fbBuffer.Resize(nSize := THIS^.fbBuffer.nBufferSize + SIZEOF(THIS^.pipObserver),
-                      bPreserve := TRUE,
-                      bReset := FALSE);
-
-THIS^.pipObserver := THIS^.fbBuffer.pBuffer;
-THIS^.pipObserver[THIS^.nLastIdx] := ipObserver;
-THIS^.NotifyLast();
-
-{IF defined(variable: aPip)}
-THIS^.UpdateDebugArray();
-{END_IF}
-
-Attach := TRUE;
 ]]></ST>
       </Implementation>
     </Method>
@@ -126,109 +81,34 @@ END_VAR
         </Implementation>
       </Set>
     </Property>
+    <Method Name="ClearAll" Id="{d2ff27ca-2474-076b-3175-e48fff67c7aa}">
+      <Declaration><![CDATA[METHOD ClearAll
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[THIS^._fbObsList.Clear();
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="Contains" Id="{76aabba0-b9ac-01e9-0b01-8a8b30e6a647}">
+      <Declaration><![CDATA[METHOD Contains : BOOL
+VAR_INPUT
+    ipObserver: I_Observer;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[Contains := THIS^._fbObsList.Contains(ipObserver);
+]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="Detach" Id="{cd87a177-86aa-454f-9754-8649faed008d}">
       <Declaration><![CDATA[METHOD Detach : BOOL
 VAR_INPUT
     ipObserver:     I_Observer;
-END_VAR
-VAR
-    i:              UDINT;
-    j:              UDINT;
-    bFoundItem:     BOOL;
-    nRemoveIdx:     UDINT;
-    pTmp:           POINTER TO BYTE;
-    nPTmpSize:      UDINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[// Validate interface pointer
-IF ipObserver = 0 THEN
-    RETURN;
-END_IF
-
-// Nothing to remove
-IF THIS^.fbBuffer.nBufferSize = 0 THEN
-    RETURN;
-END_IF
-
-// Find correct observer index to remove
-FOR i := 0 TO THIS^.nLastIdx DO
-    IF THIS^.pipObserver[i] = ipObserver THEN
-        nRemoveIdx := i;
-        bFoundItem := TRUE;
-        EXIT;
-    END_IF
-END_FOR
-
-// No item found
-IF NOT bFoundItem THEN
-    RETURN;
-
-// Found the only item to be removed
-ELSIF THIS^.nObserverCount = 1 THEN
-    THIS^.fbBuffer.Resize(nSize := 0,
-                          bPreserve := FALSE,
-                          bReset := TRUE);
-
-    THIS^.pipObserver := THIS^.fbBuffer.pBuffer;
-
-    {IF defined(variable: aPip)}
-    THIS^.UpdateDebugArray();
-    {END_IF}
-
-    Detach := TRUE;
-
-    RETURN;
-END_IF
-
-// Create temporary buffer
-nPTmpSize := fbBuffer.nBufferSize - SIZEOF(THIS^.pipObserver);
-pTmp := __NEW(BYTE, nPTmpSize);
-
-Tc2_System.MEMCPY(destAddr := pTmp,
-                  srcAddr := THIS^.pipObserver,
-                  n := nRemoveIdx*SIZEOF(POINTER TO I_Observer));
-
-IF nRemoveIdx < THIS^.nLastIdx THEN
-    Tc2_System.MEMCPY(destAddr := pTmp,
-                      srcAddr := ADR(THIS^.pipObserver[nRemoveIdx + 1]),
-                      n := (THIS^.nLastIdx - nRemoveIdx)*SIZEOF(POINTER TO I_Observer));
-END_IF
-
-// Shrink main buffer and clean the contents
-THIS^.fbBuffer.Resize(nSize := nPTmpSize,
-                      bPreserve := FALSE,
-                      bReset := TRUE);
-
-THIS^.pipObserver := fbBuffer.pBuffer;
-
-// Copy contents from temp buffer back to main buffer
-Tc2_System.MEMCPY(destAddr := THIS^.pipObserver,
-                  srcAddr := pTmp,
-                  n := nPTmpSize);
-
-// Delete temp buffer after use
-IF pTmp <> 0 THEN
-    __DELETE(pTmp);
-END_IF
-
-{IF defined(variable: aPip)}
-THIS^.UpdateDebugArray();
-{END_IF}
-
-Detach := TRUE;
-]]></ST>
-      </Implementation>
-    </Method>
-    <Method Name="FB_init" Id="{cfb9d78b-f9b9-4c25-a6c3-89cdbb34fd0b}">
-      <Declaration><![CDATA[METHOD FB_init : BOOL
-VAR_INPUT
-    bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
-    bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
-END_VAR
-]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[THIS^._bAutoNotify := bAutoNotify;
+        <ST><![CDATA[Detach := THIS^._fbObsList.Remove(ipObserver);
 ]]></ST>
       </Implementation>
     </Method>
@@ -244,22 +124,6 @@ END_VAR
         </Implementation>
       </Get>
     </Property>
-    <Property Name="nLastIdx" Id="{2c79c953-5622-435d-a939-cc4a5f7e264e}">
-      <Declaration><![CDATA[PROPERTY PROTECTED nLastIdx : UDINT]]></Declaration>
-      <Get Name="Get" Id="{c29b0475-f6df-4d45-ac76-cc7c5921980f}">
-        <Declaration><![CDATA[VAR
-END_VAR
-]]></Declaration>
-        <Implementation>
-          <ST><![CDATA[IF THIS^.fbBuffer.nBufferSize > 0 THEN
-    nLastIdx := THIS^.fbBuffer.nBufferSize/SIZEOF(THIS^.pipObserver) - 1;
-ELSE
-    nLastIdx := 0;
-END_IF
-]]></ST>
-        </Implementation>
-      </Get>
-    </Property>
     <Property Name="nObserverCount" Id="{8a1f52c0-3800-483e-a595-61cd3c373210}">
       <Declaration><![CDATA[PROPERTY nObserverCount : UDINT
 ]]></Declaration>
@@ -268,48 +132,40 @@ END_IF
 END_VAR
 ]]></Declaration>
         <Implementation>
-          <ST><![CDATA[IF THIS^.fbBuffer.nBufferSize > 0 THEN
-    nObserverCount := THIS^.nLastIdx + 1;
-ELSE
-    nObserverCount := 0;
-END_IF
+          <ST><![CDATA[nObserverCount := THIS^._fbObsList.nCount;
 ]]></ST>
         </Implementation>
       </Get>
     </Property>
-    <Method Name="Notify" Id="{50b7b6ea-de79-46bd-bf28-05ba956e9a25}">
-      <Declaration><![CDATA[METHOD Notify : I_Observable
-VAR
-    i:      UDINT;
-END_VAR]]></Declaration>
+    <Method Name="NotifyAll" Id="{50b7b6ea-de79-46bd-bf28-05ba956e9a25}">
+      <Declaration><![CDATA[METHOD NotifyAll : I_Observable
+]]></Declaration>
       <Implementation>
-        <ST><![CDATA[Notify := THIS^;
+        <ST><![CDATA[NotifyAll := THIS^;
 
-IF THIS^.nObserverCount <= 0 THEN
-    RETURN;
-END_IF
-
-FOR i := 0 TO THIS^.nLastIdx DO
-    THIS^.pipObserver[i].UpdateP(THIS^.pData,
-                                 THIS^.nDataSize,
-                                 THIS^._nTypeClass);
-END_FOR
+THIS^._fbObsList.ForEach(
+    THIS^._fbNotifyObservers
+         .Inputs(THIS^.pData,
+                 THIS^._nTypeClass,
+                 THIS^.nDataSize));
 ]]></ST>
       </Implementation>
     </Method>
     <Method Name="NotifyLast" Id="{bfb98185-9d2f-403d-8101-4e4bed875c91}">
       <Declaration><![CDATA[METHOD NotifyLast : I_Observable
-]]></Declaration>
+VAR
+    ipLastObs: I_Observer;
+END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[NotifyLast := THIS^;
 
-IF THIS^.nObserverCount <= 0 THEN
-    RETURN;
-END_IF
+ipLastObs := THIS^.ObserverAt(TO_DINT(THIS^.nObserverCount) - 1);
 
-THIS^.pipObserver[THIS^.nLastIdx].UpdateP(THIS^.pData,
-                                          THIS^.nDataSize,
-                                          THIS^._nTypeClass);
+IF ipLastObs <> 0 THEN
+    ipLastObs.UpdateP(pData := THIS^.pData,
+                      nTypeClass := THIS^._nTypeClass,
+                      nSize := THIS^.nDataSize);
+END_IF
 ]]></ST>
       </Implementation>
     </Method>
@@ -330,7 +186,7 @@ IF THIS^._bNotifyWhenChanged
     RETURN;
 END_IF
 
-THIS^.Notify();
+THIS^.NotifyAll();
 ]]></ST>
       </Implementation>
     </Method>
@@ -346,6 +202,17 @@ END_VAR
         </Implementation>
       </Get>
     </Property>
+    <Method Name="ObserverAt" Id="{b9e320b9-08ab-450b-b4c7-7a324f7bf6f8}">
+      <Declaration><![CDATA[METHOD ObserverAt : I_Observer
+VAR_INPUT
+    nIdx: DINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[__QUERYINTERFACE(THIS^._fbObsList.ItemAt(nIdx), ObserverAt);
+]]></ST>
+      </Implementation>
+    </Method>
     <Property Name="pData" Id="{dc2c7af6-7d54-4c13-8681-c25bac9e7fcb}">
       <Declaration><![CDATA[PROPERTY PROTECTED ABSTRACT pData : POINTER TO BYTE]]></Declaration>
       <Get Name="Get" Id="{13c43774-fcc5-43db-b9fd-56325378b403}">
@@ -357,27 +224,6 @@ END_VAR
         </Implementation>
       </Get>
     </Property>
-    <Method Name="UpdateDebugArray" Id="{d2dd83c4-e423-4d5c-abb7-4b336ab5b071}">
-      <Declaration><![CDATA[METHOD PRIVATE UpdateDebugArray : BOOL
-VAR_INPUT
-END_VAR
-VAR
-    i:                  UDINT;
-END_VAR]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[{IF defined(variable: aPip)}
-MEMSET(
-    destAddr := ADR(THIS^.aPip),
-    fillByte := 0,
-    n := SIZEOF(THIS^.aPip));
-
-FOR i := 0 TO THIS^.nLastIdx DO
-    THIS^.aPip[i] := ADR(THIS^.pipObserver[i]);
-END_FOR
-{END_IF}
-]]></ST>
-      </Implementation>
-    </Method>
     <Method Name="ValueChanged" Id="{010c3d67-bfde-02a5-1223-efc7d35699a5}">
       <Declaration><![CDATA[METHOD ABSTRACT ValueChanged : BOOL
 VAR_INPUT

--- a/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/FB_AbstractObserver.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/FB_AbstractObserver.TcPOU
@@ -12,34 +12,12 @@ END_VAR
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
-    <Method Name="_Update" Id="{4a80772a-c77d-08e0-0400-3dfaeedba93e}">
+    <Method Name="_Update" Id="{04601ce4-ef10-086c-2ba8-698f7bbc7727}">
       <Declaration><![CDATA[METHOD PROTECTED _Update
 VAR_INPUT
-    anyVal:         ANY;
-END_VAR
-VAR
-    nMemcpyRes:     UDINT;
-END_VAR
-]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[IF anyVal.TypeClass = THIS^._nTypeClass THEN
-    nMemcpyRes := Tc2_System.MEMCPY(destAddr := THIS^._pVal,
-                                    srcAddr := anyVal.pValue,
-                                    n := TO_UDINT(anyVal.diSize));
-END_IF
-
-IF nMemcpyRes <> 0 THEN
-    THIS^._nUpdateCounter := THIS^._nUpdateCounter + 1;
-END_IF
-]]></ST>
-      </Implementation>
-    </Method>
-    <Method Name="_UpdateP" Id="{04601ce4-ef10-086c-2ba8-698f7bbc7727}">
-      <Declaration><![CDATA[METHOD PROTECTED _UpdateP
-VAR_INPUT
     pData:          POINTER TO BYTE;
-    nSize:          UDINT;
     nTypeClass:     __SYSTEM.TYPE_CLASS;
+    nSize:          UDINT;
 END_VAR
 VAR
     nMemcpyRes:     UDINT;
@@ -109,7 +87,9 @@ END_VAR
       <Implementation>
         <ST><![CDATA[THIS^.PreUpdate();
 
-THIS^._Update(anyVal);
+THIS^._Update(pData := anyVal.pValue,
+              nTypeClass := anyVal.TypeClass,
+              nSize := TO_UDINT(anyVal.diSize));
 
 THIS^.PostUpdate();
 ]]></ST>
@@ -121,13 +101,15 @@ THIS^.PostUpdate();
    variable information *)
 VAR_INPUT
     pData:          POINTER TO BYTE;
-    nSize:          UDINT;
     nTypeClass:     __SYSTEM.TYPE_CLASS;
+    nSize:          UDINT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[THIS^.PreUpdate();
 
-THIS^._UpdateP(pData, nSize, nTypeClass);
+THIS^._Update(pData := pData,
+              nTypeClass := nTypeClass,
+              nSize := nSize);
 
 THIS^.PostUpdate();
 ]]></ST>

--- a/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/I_Observable.TcIO
+++ b/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/I_Observable.TcIO
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <Itf Name="I_Observable" Id="{e9d5ee08-eb7e-494a-b197-8f922f772785}">
-    <Declaration><![CDATA[INTERFACE I_Observable EXTENDS __SYSTEM.IQueryInterface
+    <Declaration><![CDATA[INTERFACE I_Observable EXTENDS I_Object
 ]]></Declaration>
     <Method Name="Attach" Id="{30211a61-21d5-40ca-8122-c8c8f2acdb97}">
       <Declaration><![CDATA[METHOD Attach : BOOL
@@ -50,8 +50,8 @@ END_VAR
         <Declaration><![CDATA[]]></Declaration>
       </Get>
     </Property>
-    <Method Name="Notify" Id="{dca0986e-fc2a-4198-a535-6eefd7c6a6f6}">
-      <Declaration><![CDATA[METHOD Notify : I_Observable
+    <Method Name="NotifyAll" Id="{dca0986e-fc2a-4198-a535-6eefd7c6a6f6}">
+      <Declaration><![CDATA[METHOD NotifyAll : I_Observable
 VAR_INPUT
 END_VAR
 ]]></Declaration>

--- a/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/I_Observer.TcIO
+++ b/TcBase/TcBase/TcBase/Observer Pattern/Abstraction/I_Observer.TcIO
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <Itf Name="I_Observer" Id="{71e9c537-c1c0-4a93-aa9e-3a7f11d757ab}">
-    <Declaration><![CDATA[INTERFACE I_Observer EXTENDS __SYSTEM.IQueryInterface
+    <Declaration><![CDATA[INTERFACE I_Observer EXTENDS I_Object
 ]]></Declaration>
     <Property Name="nTypeClass" Id="{45bcd299-a5df-005e-250a-29bf5493035a}">
       <Declaration><![CDATA[PROPERTY nTypeClass : __SYSTEM.TYPE_CLASS]]></Declaration>
@@ -20,8 +20,8 @@ END_VAR
       <Declaration><![CDATA[METHOD UpdateP
 VAR_INPUT
     pData:          POINTER TO BYTE;
-    nSize:          UDINT;
     nTypeClass:     __SYSTEM.TYPE_CLASS;
+    nSize:          UDINT;
 END_VAR
 ]]></Declaration>
     </Method>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_BOOL.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_BOOL.TcPOU
@@ -39,7 +39,6 @@ THIS^.NotifyWithConditions();
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_BYTE.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_BYTE.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_DINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_DINT.TcPOU
@@ -16,7 +16,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_DWORD.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_DWORD.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_INT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_INT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_LINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_LINT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_LREAL.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_LREAL.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_LWORD.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_LWORD.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_REAL.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_REAL.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_SINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_SINT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_UDINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_UDINT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_UINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_UINT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_ULINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_ULINT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_USINT.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_USINT.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_WORD.TcPOU
+++ b/TcBase/TcBase/TcBase/Observer Pattern/FB_Observable_WORD.TcPOU
@@ -15,7 +15,6 @@ END_VAR
 VAR_INPUT
     bInitRetains:       BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
     bInCopyCode:        BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-    bAutoNotify:        BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcBase/TcBase/TcBase/Observer Pattern/Param_Observer.TcGVL
+++ b/TcBase/TcBase/TcBase/Observer Pattern/Param_Observer.TcGVL
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
-  <GVL Name="Param_Observer" Id="{2d769b2c-14a5-4d82-9d5e-2e0563cc4466}" ParameterList="True">
-    <Declaration><![CDATA[{attribute 'qualified_only'}
-VAR_GLOBAL CONSTANT
-    cMaxNumberOfObservers:      UDINT := 50;
-END_VAR]]></Declaration>
-  </GVL>
-</TcPlcObject>

--- a/TcBase/TcBase/TcBase/TcBase.plcproj
+++ b/TcBase/TcBase/TcBase/TcBase.plcproj
@@ -45,6 +45,7 @@
     <Folder Include="Object" />
     <Folder Include="Observer Pattern" />
     <Folder Include="Observer Pattern\Abstraction" />
+    <Folder Include="Observer Pattern\Abstraction\Actions" />
     <Folder Include="Project Information" />
     <Folder Include="Restorable" />
     <Folder Include="State Pattern" />
@@ -97,6 +98,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Object\I_Object.TcIO">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Observer Pattern\Abstraction\Actions\FB_NotifyObserverAction.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Observer Pattern\Abstraction\FB_AbstractObservable.TcPOU">
@@ -203,10 +207,6 @@
     </Compile>
     <Compile Include="Observer Pattern\FB_Observer_WORD.TcPOU">
       <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Observer Pattern\Param_Observer.TcGVL">
-      <SubType>Code</SubType>
-      <LinkAlways>true</LinkAlways>
     </Compile>
     <Compile Include="Project Information\F_GetCompany.TcPOU">
       <SubType>Code</SubType>

--- a/TcBaseTest/TcBaseTest/TcBaseTest.tsproj
+++ b/TcBaseTest/TcBaseTest/TcBaseTest.tsproj
@@ -23,7 +23,7 @@
 						<Defines></Defines>
 					</Variant>
 				</ProjectVariant>
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" TmcPath="TcBaseTest\TcBaseTest.tmc" TmcHash="{0563946A-E692-F112-1FA9-3FE63D865C6E}">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" TmcPath="TcBaseTest\TcBaseTest.tmc" TmcHash="{DB8B7F8D-53F9-A85F-AB02-9B6B3F2488D2}">
 					<Name>TcBaseTest Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 					<Contexts>

--- a/TcBaseTest/TcBaseTest/TcBaseTest/Observer Pattern Test/FB_ObserverPattern_Test.TcPOU
+++ b/TcBaseTest/TcBaseTest/TcBaseTest/Observer Pattern Test/FB_ObserverPattern_Test.TcPOU
@@ -14,24 +14,24 @@ END_VAR
       <ST><![CDATA[TestAdd5CompatibleObserversExpectAll5();
 TestAdd6IncompatibleObserversExpectNone();
 TestAddDuplicateObserversExpectFailure();
-TestAddMoreObserversThanAllowedExpectOnlyMaxCount();
+TestAddNullObserverExpectFailure();
+TestClearAllObserversExpectSuccess();
 TestCompatibleDataTypesExpectValuesToUpdate();
 TestDataTypeConsistencyOfObservables();
 TestDataTypeConsistencyOfObservers();
 TestDetachAddedObserversExpectSuccess();
+TestExternalWithCompatibleDataTypeExpectValueToUpdate();
 TestIncompatileDataTypesExpectNoValueChange();
-TestObservableNotifyAlwaysUponWriteAccess();
-TestObservableNotifyOnlyWhenValueChanged();
-TestObservableNotifyUponAttachmentWithObservers();
-TestObserverExternalWithCompatibleDataTypeExpectValueToUpdate();
+TestNotifyAlwaysUponWriteAccess();
+TestNotifyOnlyWhenValueChanged();
+TestNotifyUponAttachmentWithObservers();
 TestOneObservableToManyObserversExpectAllToUpdateValueAccordingly();
 ]]></ST>
     </Implementation>
     <Method Name="TestAdd5CompatibleObserversExpectAll5" Id="{791da87e-3b1e-4df9-be32-6b1c00308983}">
       <Declaration><![CDATA[METHOD PRIVATE TestAdd5CompatibleObserversExpectAll5
 VAR_INST
-    fbObservableReal: FB_Observable_REAL(TRUE);
-
+    fbObservableReal: FB_Observable_REAL;
     aObserverReal: ARRAY [1..5] OF FB_Observer_REAL;
 
     i: UDINT;
@@ -57,11 +57,11 @@ TcUnit.TEST_FINISHED();
       <Declaration><![CDATA[METHOD PRIVATE TestAdd6IncompatibleObserversExpectNone
 VAR_INST
     // Test can be less manual with dynamic list
-    fbObservableDint: FB_Observable_DINT(TRUE);
-    fbObservableUdint: FB_Observable_UDINT(TRUE);
-    fbObservableUint: FB_Observable_UINT(TRUE);
-    fbObservableReal: FB_Observable_REAL(TRUE);
-    fbObservableLreal: FB_Observable_LREAL(TRUE);
+    fbObservableDint: FB_Observable_DINT;
+    fbObservableUdint: FB_Observable_UDINT;
+    fbObservableUint: FB_Observable_UINT;
+    fbObservableReal: FB_Observable_REAL;
+    fbObservableLreal: FB_Observable_LREAL;
 
     fbObserverDint: ARRAY [1..6] OF FB_Observer_DINT;
     fbObserverUdint: ARRAY [1..6] OF FB_Observer_UDINT;
@@ -130,7 +130,7 @@ TcUnit.TEST_FINISHED();
     <Method Name="TestAddDuplicateObserversExpectFailure" Id="{541af2f9-185f-04a2-08d3-89d5044bece3}">
       <Declaration><![CDATA[METHOD PRIVATE TestAddDuplicateObserversExpectFailure
 VAR_INST
-    fbObservableReal: FB_Observable_REAL(TRUE);
+    fbObservableReal: FB_Observable_REAL;
 
     fbObserverReal: FB_Observer_REAL;
 
@@ -158,26 +158,45 @@ TcUnit.TEST_FINISHED();
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="TestAddMoreObserversThanAllowedExpectOnlyMaxCount" Id="{0c149026-c1e8-4c39-92b6-923e4107cb0e}">
-      <Declaration><![CDATA[METHOD PRIVATE TestAddMoreObserversThanAllowedExpectOnlyMaxCount
+    <Method Name="TestAddNullObserverExpectFailure" Id="{3d253d5b-1e64-4c0a-b007-ed6e12377370}">
+      <Declaration><![CDATA[METHOD PRIVATE TestAddNullObserverExpectFailure
 VAR_INST
-    fbObservableReal: FB_Observable_REAL(TRUE);
+    ipNullObs: I_Observer;
+    fbObservable: FB_Observable_LREAL;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TcUnit.TEST('TestAddNullObserverExpectFailure');
 
-    fbObserverReal: ARRAY [1..(TcBase.Param_Observer.cMaxNumberOfObservers+10)] OF FB_Observer_REAL;
+fbObservable.Attach(ipNullObs);
+
+THIS^.AssertEquals_UDINT(Expected := 0,
+                         Actual := fbObservable.nObserverCount,
+                         Message := 'Invalid observer added');
+
+TcUnit.TEST_FINISHED();
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="TestClearAllObserversExpectSuccess" Id="{902743db-2fee-42b6-86b8-67b8f28610c2}">
+      <Declaration><![CDATA[METHOD PRIVATE TestClearAllObserversExpectSuccess
+VAR_INST
+    fbObservableReal: FB_Observable_REAL;
+    aObserverReal: ARRAY [1..5] OF FB_Observer_REAL;
 
     i: UDINT;
-END_VAR
-]]></Declaration>
+END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[TcUnit.TEST('TestAddMoreObserversThanAllowedExpectOnlyMaxCount');
+        <ST><![CDATA[TcUnit.TEST('TestClearAllObserversExpectSuccess');
 
-FOR i := 1 TO SIZEOF(fbObserverReal)/SIZEOF(fbObserverReal[1]) DO
-    fbObservableReal.Attach(fbObserverReal[i]);
+FOR i := 1 TO SIZEOF(aObserverReal)/SIZEOF(aObserverReal[1]) DO
+    fbObservableReal.Attach(aObserverReal[i]);
 END_FOR
 
-THIS^.AssertEquals_UDINT(Expected := TcBase.Param_Observer.cMaxNumberOfObservers,
+fbObservableReal.ClearAll();
+
+THIS^.AssertEquals_UDINT(Expected := 0,
                          Actual := fbObservableReal.nObserverCount,
-                         Message := 'Unexpected number of observers attached');
+                         Message := 'Failed to clear all observers');
 
 TcUnit.TEST_FINISHED();
 ]]></ST>
@@ -186,21 +205,21 @@ TcUnit.TEST_FINISHED();
     <Method Name="TestCompatibleDataTypesExpectValuesToUpdate" Id="{a0c42179-d282-4d90-9f50-7c032bf816e4}">
       <Declaration><![CDATA[METHOD PRIVATE TestCompatibleDataTypesExpectValuesToUpdate
 VAR_INST
-    fbObservableBool: FB_Observable_BOOL(TRUE);
-    fbObservableByte: FB_Observable_BYTE(TRUE);
-    fbObservableWord: FB_Observable_WORD(TRUE);
-    fbObservableDword: FB_Observable_DWORD(TRUE);
-    fbObservableLword: FB_Observable_LWORD(TRUE);
-    fbObservableSint: FB_Observable_SINT(TRUE);
-    fbObservableUsint: FB_Observable_USINT(TRUE);
-    fbObservableInt: FB_Observable_INT(TRUE);
-    fbObservableUint: FB_Observable_UINT(TRUE);
-    fbObservableDint: FB_Observable_DINT(TRUE);
-    fbObservableUdint: FB_Observable_UDINT(TRUE);
-    fbObservableLint: FB_Observable_LINT(TRUE);
-    fbObservableUlint: FB_Observable_ULINT(TRUE);
-    fbObservableLreal: FB_Observable_LREAL(TRUE);
-    fbObservableReal: FB_Observable_REAL(TRUE);
+    fbObservableBool: FB_Observable_BOOL;
+    fbObservableByte: FB_Observable_BYTE;
+    fbObservableWord: FB_Observable_WORD;
+    fbObservableDword: FB_Observable_DWORD;
+    fbObservableLword: FB_Observable_LWORD;
+    fbObservableSint: FB_Observable_SINT;
+    fbObservableUsint: FB_Observable_USINT;
+    fbObservableInt: FB_Observable_INT;
+    fbObservableUint: FB_Observable_UINT;
+    fbObservableDint: FB_Observable_DINT;
+    fbObservableUdint: FB_Observable_UDINT;
+    fbObservableLint: FB_Observable_LINT;
+    fbObservableUlint: FB_Observable_ULINT;
+    fbObservableLreal: FB_Observable_LREAL;
+    fbObservableReal: FB_Observable_REAL;
 
     fbObserverBool: FB_Observer_BOOL;
     fbObserverByte: FB_Observer_BYTE;
@@ -332,21 +351,21 @@ VAR_INST
         ];
 
     fbList: FB_List;
-    fbObservableBool: FB_Observable_BOOL(TRUE);
-    fbObservableByte: FB_Observable_BYTE(TRUE);
-    fbObservableWord: FB_Observable_WORD(TRUE);
-    fbObservableDword: FB_Observable_DWORD(TRUE);
-    fbObservableLword: FB_Observable_LWORD(TRUE);
-    fbObservableSint: FB_Observable_SINT(TRUE);
-    fbObservableUsint: FB_Observable_USINT(TRUE);
-    fbObservableInt: FB_Observable_INT(TRUE);
-    fbObservableUint: FB_Observable_UINT(TRUE);
-    fbObservableDint: FB_Observable_DINT(TRUE);
-    fbObservableUdint: FB_Observable_UDINT(TRUE);
-    fbObservableLint: FB_Observable_LINT(TRUE);
-    fbObservableUlint: FB_Observable_ULINT(TRUE);
-    fbObservableLreal: FB_Observable_LREAL(TRUE);
-    fbObservableReal: FB_Observable_REAL(TRUE);
+    fbObservableBool: FB_Observable_BOOL;
+    fbObservableByte: FB_Observable_BYTE;
+    fbObservableWord: FB_Observable_WORD;
+    fbObservableDword: FB_Observable_DWORD;
+    fbObservableLword: FB_Observable_LWORD;
+    fbObservableSint: FB_Observable_SINT;
+    fbObservableUsint: FB_Observable_USINT;
+    fbObservableInt: FB_Observable_INT;
+    fbObservableUint: FB_Observable_UINT;
+    fbObservableDint: FB_Observable_DINT;
+    fbObservableUdint: FB_Observable_UDINT;
+    fbObservableLint: FB_Observable_LINT;
+    fbObservableUlint: FB_Observable_ULINT;
+    fbObservableLreal: FB_Observable_LREAL;
+    fbObservableReal: FB_Observable_REAL;
 
     ipTmp: I_Observable;
     i: UDINT;
@@ -456,7 +475,7 @@ TcUnit.TEST_FINISHED();
     <Method Name="TestDetachAddedObserversExpectSuccess" Id="{d0a8dd44-ed9b-0741-3658-2e78db7d42e9}">
       <Declaration><![CDATA[METHOD PRIVATE TestDetachAddedObserversExpectSuccess
 VAR_INST
-    fbObservableReal: FB_Observable_REAL(TRUE);
+    fbObservableReal: FB_Observable_REAL;
     fbObserverReal: ARRAY [1..5] OF FB_Observer_REAL;
 
     i: UDINT;
@@ -483,10 +502,36 @@ TcUnit.TEST_FINISHED();
 ]]></ST>
       </Implementation>
     </Method>
+    <Method Name="TestExternalWithCompatibleDataTypeExpectValueToUpdate" Id="{10be65a2-219d-0b3c-1bbe-50f6d1861ef6}">
+      <Declaration><![CDATA[METHOD PRIVATE TestExternalWithCompatibleDataTypeExpectValueToUpdate
+VAR_INST
+    fbObservableLreal: FB_Observable_LREAL;
+    fbObserverExt: FB_ObserverExt(THIS^.fVal);
+    aTestVal: ARRAY [1..5] OF LREAL :=
+        [2.7183, 3.1415, -1, 1.6180, 6.6261];
+    i: UDINT;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TcUnit.TEST('TestObserverExternalWithCompatibleDataTypeExpectValueToUpdate');
+
+fbObservableLreal.Attach(fbObserverExt);
+
+FOR i := 1 TO SIZEOF(aTestVal)/SIZEOF(aTestVal[1]) DO
+    fbObservableLreal.fValue64 := aTestVal[i];
+    THIS^.AssertEquals_LREAL(Expected := aTestVal[i],
+                             Actual := THIS^.fVal,
+                             Delta := 0.001,
+                             Message := 'External observer typed LREAL failed to update value according to observable');
+END_FOR
+
+TcUnit.TEST_FINISHED();
+]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="TestIncompatileDataTypesExpectNoValueChange" Id="{0979a056-7376-4db3-99e3-658aa0013606}">
       <Declaration><![CDATA[METHOD PRIVATE TestIncompatileDataTypesExpectNoValueChange
 VAR_INST
-    fbObservableReal: FB_Observable_REAL(TRUE);
+    fbObservableReal: FB_Observable_REAL;
 
     fbObserverDint: FB_Observer_DINT;
     fbObserverUdint: FB_Observer_UDINT;
@@ -528,21 +573,21 @@ TcUnit.TEST_FINISHED();
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="TestObservableNotifyAlwaysUponWriteAccess" Id="{6bd03110-3809-4b9a-be1d-26037011bd0e}">
-      <Declaration><![CDATA[METHOD PRIVATE TestObservableNotifyAlwaysUponWriteAccess
+    <Method Name="TestNotifyAlwaysUponWriteAccess" Id="{6bd03110-3809-4b9a-be1d-26037011bd0e}">
+      <Declaration><![CDATA[METHOD PRIVATE TestNotifyAlwaysUponWriteAccess
 VAR_INST
-    fbObservable: FB_Observable_LREAL(TRUE);
+    fbObservable: FB_Observable_LREAL;
     fbObserver: FB_Observer_LREAL_;
 
     i: UDINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[TcUnit.TEST('TestObservableNotifyAlwaysUponWriteAccess');
+        <ST><![CDATA[TcUnit.TEST('TestNotifyAlwaysUponWriteAccess');
 
 fbObservable.bNotifyWhenChanged := FALSE;
 fbObservable.Attach(fbObserver);
 
-// Expecte 1 update already because observable always update its observer upon
+// Expect 1 update already because observable always update its observer upon
 // attachment
 THIS^.AssertEquals_UDINT(Expected := 1,
                          Actual := fbObserver.nUpdateCounter,
@@ -560,10 +605,10 @@ TcUnit.TEST_FINISHED();
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="TestObservableNotifyOnlyWhenValueChanged" Id="{22acf0a5-0c89-4f61-b880-4714e2c4dc93}">
-      <Declaration><![CDATA[METHOD PRIVATE TestObservableNotifyOnlyWhenValueChanged
+    <Method Name="TestNotifyOnlyWhenValueChanged" Id="{22acf0a5-0c89-4f61-b880-4714e2c4dc93}">
+      <Declaration><![CDATA[METHOD PRIVATE TestNotifyOnlyWhenValueChanged
 VAR_INST
-    fbObservable: FB_Observable_LREAL(TRUE);
+    fbObservable: FB_Observable_LREAL;
     fbObserver: FB_Observer_LREAL_;
     aVal: ARRAY [1..5] OF LREAL :=
         [2.7183, 3.1415, -1, 1.6180, 6.6261];
@@ -572,8 +617,9 @@ VAR_INST
     j: UDINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[TcUnit.TEST('TestObservableNotifyOnlyWhenValueChanged');
+        <ST><![CDATA[TcUnit.TEST('TestNotifyOnlyWhenValueChanged');
 
+fbObservable.bNotifyWhenChanged := TRUE;
 fbObservable.Attach(fbObserver);
 
 // Expect 1 update already because observable always update its observer upon
@@ -597,16 +643,16 @@ TcUnit.TEST_FINISHED();
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="TestObservableNotifyUponAttachmentWithObservers" Id="{80e2d94c-c26a-4a53-990f-cd6227123e7b}">
-      <Declaration><![CDATA[METHOD PRIVATE TestObservableNotifyUponAttachmentWithObservers
+    <Method Name="TestNotifyUponAttachmentWithObservers" Id="{80e2d94c-c26a-4a53-990f-cd6227123e7b}">
+      <Declaration><![CDATA[METHOD PRIVATE TestNotifyUponAttachmentWithObservers
 VAR_INST
-    fbObservable: FB_Observable_LREAL(TRUE);
+    fbObservable: FB_Observable_LREAL;
     aObserver: ARRAY [1..5] OF FB_Observer_LREAL_;
 
     i: UDINT;
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[TcUnit.TEST('TestObservableNotifyUponAttachmentWithObservers');
+        <ST><![CDATA[TcUnit.TEST('TestNotifyUponAttachmentWithObservers');
 
 fbObservable.fValue64 := 100.0;
 
@@ -628,36 +674,10 @@ TcUnit.TEST_FINISHED();
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="TestObserverExternalWithCompatibleDataTypeExpectValueToUpdate" Id="{10be65a2-219d-0b3c-1bbe-50f6d1861ef6}">
-      <Declaration><![CDATA[METHOD PRIVATE TestObserverExternalWithCompatibleDataTypeExpectValueToUpdate
-VAR_INST
-    fbObservableLreal: FB_Observable_LREAL(TRUE);
-    fbObserverExt: FB_ObserverExt(THIS^.fVal);
-    aTestVal: ARRAY [1..5] OF LREAL :=
-        [2.7183, 3.1415, -1, 1.6180, 6.6261];
-    i: UDINT;
-END_VAR]]></Declaration>
-      <Implementation>
-        <ST><![CDATA[TcUnit.TEST('TestObserverExternalWithCompatibleDataTypeExpectValueToUpdate');
-
-fbObservableLreal.Attach(fbObserverExt);
-
-FOR i := 1 TO SIZEOF(aTestVal)/SIZEOF(aTestVal[1]) DO
-    fbObservableLreal.fValue64 := aTestVal[i];
-    THIS^.AssertEquals_LREAL(Expected := aTestVal[i],
-                             Actual := THIS^.fVal,
-                             Delta := 0.001,
-                             Message := 'External observer typed LREAL failed to update value according to observable');
-END_FOR
-
-TcUnit.TEST_FINISHED();
-]]></ST>
-      </Implementation>
-    </Method>
     <Method Name="TestOneObservableToManyObserversExpectAllToUpdateValueAccordingly" Id="{6c79a3a7-11b6-0c82-0376-6a2fc2c49511}">
       <Declaration><![CDATA[METHOD PRIVATE TestOneObservableToManyObserversExpectAllToUpdateValueAccordingly
 VAR_INST
-    fbObservableLreal: FB_Observable_LREAL(TRUE);
+    fbObservableLreal: FB_Observable_LREAL;
     aObservers: ARRAY [1..5] OF FB_Observer_LREAL;
     aTestVal: ARRAY [1..5] OF LREAL :=
         [2.7183, 3.1415, -1, 1.6180, 6.6261];


### PR DESCRIPTION
- Added `ClearAll()` to Observable
- Remove the need to specify `bAutoNotify` in `FB_init`, default value set to TRUE
- Default value for `bNotifyWhenChanged` changed to FALSE
- Removed Param_Observer
- Added more unit-tests for observer pattern
- Removed _Update() from FB_AbstractObserver and renamed _UpdateP() to _Update() since both of them were doing the same thing differently
- General refactoring to be more explicit when declaring method inputs